### PR TITLE
feat: update SDK to v0.0.53

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install
 npm run build-bundle
 ```
 
-The above command will generate the `dist` folder, containing the bundled JavaScript file named `DecreaseVolumeOnSpeak.js`. This file can be hosted on any HTTPS server.
+The above command will generate the `dist` folder, containing the bundled JavaScript file named `GenericLinkShare.js`. This file can be hosted on any HTTPS server.
 
 To use the plugin with BigBlueButton, add the plugin's URL to `settings.yml` as shown below:
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ npm start
       url: http://127.0.0.1:4701/static/GenericLinkShare.js
       dataChannels:
         - name: urlToGenericLink
-          writePermission: ['moderator','presenter']
-          deletePermission: ['moderator', 'sender']
+          pushPermission: ['moderator','presenter']
+          replaceOrdeletePermission: 
+            - moderator
+            - sender
 ```
 
 ## Building the Plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/react": "^18.2.13",
         "@types/react-dom": "^18.2.7",
         "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "bigbluebutton-html-plugin-sdk": "0.0.48",
+        "bigbluebutton-html-plugin-sdk": "0.0.53",
         "path": "^0.12.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3550,9 +3550,9 @@
       "dev": true
     },
     "node_modules/bigbluebutton-html-plugin-sdk": {
-      "version": "0.0.48",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.48.tgz",
-      "integrity": "sha512-t6z8zc5NkXKWXDVRqddxMCVOuIHVfDnPlpehW/JyskSJXED6ET0dVaRi3heiRh8PfsKP729xpnusqpg9/QE2RA==",
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.53.tgz",
+      "integrity": "sha512-+MXTl3KB45uPdZOhW74f0QIxcrW0sC+hSMGN+rGjDOpfhnDxKSSezTMogu/mbth23yJUJcSUlKw9BV9pTtEtvA==",
       "dependencies": {
         "@apollo/client": "^3.8.7",
         "@browser-bunyan/console-formatted-stream": "^1.8.0",
@@ -12155,9 +12155,9 @@
       "dev": true
     },
     "bigbluebutton-html-plugin-sdk": {
-      "version": "0.0.48",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.48.tgz",
-      "integrity": "sha512-t6z8zc5NkXKWXDVRqddxMCVOuIHVfDnPlpehW/JyskSJXED6ET0dVaRi3heiRh8PfsKP729xpnusqpg9/QE2RA==",
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.53.tgz",
+      "integrity": "sha512-+MXTl3KB45uPdZOhW74f0QIxcrW0sC+hSMGN+rGjDOpfhnDxKSSezTMogu/mbth23yJUJcSUlKw9BV9pTtEtvA==",
       "requires": {
         "@apollo/client": "^3.8.7",
         "@browser-bunyan/console-formatted-stream": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@types/react": "^18.2.13",
     "@types/react-dom": "^18.2.7",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
-    "bigbluebutton-html-plugin-sdk": "0.0.48",
+    "bigbluebutton-html-plugin-sdk": "0.0.53",
     "path": "^0.12.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/generic-link-share/component.tsx
+++ b/src/components/generic-link-share/component.tsx
@@ -5,7 +5,7 @@ import {
   ActionButtonDropdownOption,
   ActionButtonDropdownSeparator,
   BbbPluginSdk,
-  GenericComponent,
+  GenericContentMainArea,
   PluginApi,
   LayoutPresentatioAreaUiDataNames,
   UiLayouts,
@@ -25,7 +25,7 @@ function GenericLinkShare(
   const [showingPresentationContent, setShowingPresentationContent] = useState(false);
   const { data: currentUser } = pluginApi.useCurrentUser();
   const [link, setLink] = useState<string>(null);
-  const [data, dispatcher] = pluginApi.useDataChannel<DataToGenericLink>('urlToGenericLink');
+  const {data: data, pushEntry: dispatcher} = pluginApi.useDataChannel<DataToGenericLink>('urlToGenericLink');
   const [linkError, setLinkError] = useState<string>(null);
   const [previousModalState, setPreviousModalState] = useState<DataToGenericLink>({
     isUrlSameForRole: true,
@@ -40,8 +40,8 @@ function GenericLinkShare(
 
   useEffect(() => {
     const isGenericComponentInPile = currentLayout.some((gc) => (
-      gc.currentElement === UiLayouts.GENERIC_COMPONENT
-      && gc.genericComponentId === genericComponentId
+      gc.currentElement === UiLayouts.GENERIC_CONTENT
+      && gc.genericContentId === genericComponentId
     ));
     if (isGenericComponentInPile) {
       setShowingPresentationContent(true);
@@ -184,9 +184,9 @@ function GenericLinkShare(
 
   useEffect(() => {
     if (link && link !== '') {
-      pluginApi.setGenericComponents([]);
-      setGenericComponentId(pluginApi.setGenericComponents([
-        new GenericComponent({
+      pluginApi.setGenericContentItems([]);
+      setGenericComponentId(pluginApi.setGenericContentItems([
+        new GenericContentMainArea({
           contentFunction: (element: HTMLElement) => {
             const root = ReactDOM.createRoot(element);
             root.render(
@@ -200,7 +200,7 @@ function GenericLinkShare(
         }),
       ])[0]);
     } else {
-      pluginApi.setGenericComponents([]);
+      pluginApi.setGenericContentItems([]);
     }
   }, [link]);
 


### PR DESCRIPTION
This PR updates the SDK version to v0.0.53 and makes the necessary changes in code to make it work with it:
 - GenericComponent -> GenericContentMainArea
 - Object destruction on useDataChannel return
 
Additionally it fixes an issue where the shared link could not be removed(3130e7d934ae653c1054026fc2ec3aedf1bf35b7) and does a minor tweak to the readme file(e146af5c77d1c3d7caef98a42c8cc44be28f93a1).