### PR TITLE
feat: add support for presentation tags

### DIFF
--- a/src/components/generic-link-share/component.tsx
+++ b/src/components/generic-link-share/component.tsx
@@ -89,7 +89,7 @@ function GenericLinkShare(
             deleteEntryUrlToGenericLink([RESET_DATA_CHANNEL]);
             pushEntryUrlToGenericLink({
               url: tag.presenter,
-              isUrlSameForRole: tag.presenter===tag.viewer,
+              isUrlSameForRole: tag.presenter === tag.viewer,
               viewerUrl: tag.viewer,
             });
           },

--- a/src/components/modal-to-share-link/types.ts
+++ b/src/components/modal-to-share-link/types.ts
@@ -10,3 +10,9 @@ export interface ModalToShareLinkProps {
     handleSendLinkToIframe: (e: React.SyntheticEvent) => void;
     handleCheckboxChange: () => void
 }
+
+export interface LinkTag {
+    title: string;
+    viewer: string;
+    presenter?: string;
+}

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -1,7 +1,22 @@
-import { pluginLogger } from "bigbluebutton-html-plugin-sdk";
-import { LinkTag } from "./modal-to-share-link/types";
+import { pluginLogger } from 'bigbluebutton-html-plugin-sdk';
+import { LinkTag } from './modal-to-share-link/types';
 
-export function parseTags (text: string) : LinkTag[]{
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function hasRequiredFields(obj: any): obj is LinkTag {
+  return typeof obj.title === 'string' && typeof obj.viewer === 'string';
+}
+
+function isValidJson(stringfiedObject: string): null | object {
+  let jsonObject;
+  try {
+    jsonObject = JSON.parse(stringfiedObject);
+  } catch (error) {
+    return null;
+  }
+  return jsonObject;
+}
+
+export function parseTags(text: string) : LinkTag[] {
   const SEARCH_PATTERN = /link\s*({[^}]*})/gmi;
   // to keep the while loop in a finite and sane number of iterations
   // also because the presentation toolbar does not accomodate
@@ -10,15 +25,15 @@ export function parseTags (text: string) : LinkTag[]{
 
   const linkTags = [];
   let match;
-  while ((match = SEARCH_PATTERN.exec(text)) !== null
-    && match.length > 0
+  match = SEARCH_PATTERN.exec(text);
+  while ((match !== null) && match.length > 0
     && linkTags.length < MAXIMUM_TAGS) {
     const matchWhitespacesRemoved = match[1].replace(/(\r\n|\n|\r)/gm, '');
     // replaces typographical quotation marks(common on presentations) by straight ones
     const replacedQuotes = matchWhitespacesRemoved.replace(/“|”/g, '"');
     const jsonObject = isValidJson(replacedQuotes);
-    if (jsonObject){
-      if(hasRequiredFields(jsonObject)) {
+    if (jsonObject) {
+      if (hasRequiredFields(jsonObject)) {
         linkTags.push({
           title: jsonObject.title,
           viewer: jsonObject.viewer,
@@ -30,20 +45,7 @@ export function parseTags (text: string) : LinkTag[]{
     } else {
       pluginLogger.error('Link tag found but is not a valid json');
     }
+    match = SEARCH_PATTERN.exec(text);
   }
   return linkTags;
-}
-
-function isValidJson (stringifiedObject: string): null | Object {
-  let jsonObject;
-  try {
-    jsonObject = JSON.parse(stringifiedObject);
-  } catch (error) {
-    return null;
-  }
-  return jsonObject;
-}
-
-function hasRequiredFields(obj: any): obj is LinkTag {
-  return typeof obj.title === 'string' && typeof obj.viewer === 'string';
 }

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -1,0 +1,49 @@
+import { pluginLogger } from "bigbluebutton-html-plugin-sdk";
+import { LinkTag } from "./modal-to-share-link/types";
+
+export function parseTags (text: string) : LinkTag[]{
+  const SEARCH_PATTERN = /link\s*({[^}]*})/gmi;
+  // to keep the while loop in a finite and sane number of iterations
+  // also because the presentation toolbar does not accomodate
+  // too many buttons.
+  const MAXIMUM_TAGS = 3;
+
+  const linkTags = [];
+  let match;
+  while ((match = SEARCH_PATTERN.exec(text)) !== null
+    && match.length > 0
+    && linkTags.length < MAXIMUM_TAGS) {
+    const matchWhitespacesRemoved = match[1].replace(/(\r\n|\n|\r)/gm, '');
+    // replaces typographical quotation marks(common on presentations) by straight ones
+    const replacedQuotes = matchWhitespacesRemoved.replace(/“|”/g, '"');
+    const jsonObject = isValidJson(replacedQuotes);
+    if (jsonObject){
+      if(hasRequiredFields(jsonObject)) {
+        linkTags.push({
+          title: jsonObject.title,
+          viewer: jsonObject.viewer,
+          presenter: jsonObject?.presenter || jsonObject.viewer,
+        });
+      } else {
+        pluginLogger.error('Link tag does not have the minimum required fields title and viewer');
+      }
+    } else {
+      pluginLogger.error('Link tag found but is not a valid json');
+    }
+  }
+  return linkTags;
+}
+
+function isValidJson (stringifiedObject: string): null | Object {
+  let jsonObject;
+  try {
+    jsonObject = JSON.parse(stringifiedObject);
+  } catch (error) {
+    return null;
+  }
+  return jsonObject;
+}
+
+function hasRequiredFields(obj: any): obj is LinkTag {
+  return typeof obj.title === 'string' && typeof obj.viewer === 'string';
+}


### PR DESCRIPTION
Scans presentation text content for tags of generic link share. When identified, a button is displayed in the presentation toolbar to initiate the link share with the tag content.

Each tag has the format:
`link{"title": "<title_here>", "viewer": "<viewers_generic_link>", "presenter", "<presenter_generic_link>"}`

The fields 'title' and 'viewer' are mandatory, while presenter is optional. The curly braces must contain a valid JSON object whith at least 'title' and 'viewer. Other properties in the JSON object(other than 'presenter') are ignored.

A maximum of 3 tags per slide is enforced to prevent toolbar overflow.

![gif](https://github.com/bigbluebutton/plugin-generic-link-share/assets/32987232/e1082998-e060-410c-bf4f-16dc1e56dfec)
