### PR TITLE
feat: support placeholders in the URL

### DIFF
--- a/src/components/generic-link-share/component.tsx
+++ b/src/components/generic-link-share/component.tsx
@@ -22,29 +22,29 @@ import { DataToGenericLink, DecreaseVolumeOnSpeakProps } from './types';
 import { ModalToShareLink } from '../modal-to-share-link/component';
 import { LinkTag } from '../modal-to-share-link/types';
 import { REGEX } from './constants';
+import { replaceUrlPlaceholders } from './utils';
 
 function GenericLinkShare(
   { pluginUuid: uuid }: DecreaseVolumeOnSpeakProps,
 ): React.ReactElement {
   BbbPluginSdk.initialize(uuid);
-  const [showModal, setShowModal] = useState<boolean>(false);
   const pluginApi: PluginApi = BbbPluginSdk.getPluginApi(uuid);
-  const [showingPresentationContent, setShowingPresentationContent] = useState(false);
   const { data: currentUser } = pluginApi.useCurrentUser();
-  const [link, setLink] = useState<string>(null);
   const { data: urlToGenericLink, pushEntry: pushEntryUrlToGenericLink, deleteEntry: deleteEntryUrlToGenericLink } = pluginApi.useDataChannel<DataToGenericLink>('urlToGenericLink');
   const currentPresentationResponse = pluginApi.useCurrentPresentation();
+  const currentLayout = pluginApi.useUiData(LayoutPresentatioAreaUiDataNames.CURRENT_ELEMENT, [{
+    isOpen: true,
+    currentElement: UiLayouts.WHITEBOARD,
+  }]);
+  const [genericContentd, setGenericContentd] = useState<string>('');
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const [showingPresentationContent, setShowingPresentationContent] = useState(false);
+  const [link, setLink] = useState<string>(null);
   const [linkError, setLinkError] = useState<string>(null);
   const [previousModalState, setPreviousModalState] = useState<DataToGenericLink>({
     isUrlSameForRole: true,
     url: null,
   });
-  const [genericContentd, setGenericContentd] = useState<string>('');
-
-  const currentLayout = pluginApi.useUiData(LayoutPresentatioAreaUiDataNames.CURRENT_ELEMENT, [{
-    isOpen: true,
-    currentElement: UiLayouts.WHITEBOARD,
-  }]);
 
   useEffect(() => {
     const isGenericComponentInPile = currentLayout.some((gc) => (
@@ -246,7 +246,12 @@ function GenericLinkShare(
             const root = ReactDOM.createRoot(element);
             root.render(
               <GenericComponentLinkShare
-                link={link}
+                link={link && currentUser ? replaceUrlPlaceholders(link, {
+                  name: currentUser?.name ?? '',
+                  extId: currentUser?.extId ?? '',
+                  role: currentUser?.role ?? '',
+                  presenter: !!currentUser?.presenter,
+                }) : link}
               />,
             );
             return root;

--- a/src/components/generic-link-share/utils.ts
+++ b/src/components/generic-link-share/utils.ts
@@ -1,0 +1,14 @@
+type PlaceholderValues = {
+  name: string;
+  extId: string;
+  role: string;
+  presenter: boolean;
+};
+
+export function replaceUrlPlaceholders(url: string, values: PlaceholderValues): string {
+  return url
+    .replace(/{name}/g, encodeURIComponent(values.name))
+    .replace(/{extId}/g, encodeURIComponent(values.extId))
+    .replace(/{role}/g, encodeURIComponent(values.role))
+    .replace(/{presenter}/g, encodeURIComponent(String(values.presenter)));
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "outDir": "./dist-tsc/",
         "noImplicitAny": true,
+        "skipLibCheck": true,
         "module": "es6",
         "target": "es5",
         "jsx": "react",


### PR DESCRIPTION
### What does this PR do?

Creates support for injecting URL placeholders on shared links

### Closes Issue(s)
Closes #25


### Motivation

This pull request introduces support for URL placeholders in the link share plugin. The motivation stems from the need to inject user-specific information—such as the user’s name, externalId, and role—into outgoing URLs.

