### PR TITLE
feat: Support userdata placeholders 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,39 @@ pluginManifests=[{"url":"<your-domain>/path/to/manifest.json"}]
 Or additionally, you can add this same configuration in the `.properties` file from `bbb-web` in `/usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties`
 
 
+## URL Placeholders
+
+When sharing a link, you can use placeholders in the URL that will be dynamically replaced with user or session information. This allows you to personalize the shared content for each participant.
+
+### Supported Placeholders
+
+- `{name}`: The user's display name
+- `{extId}`: The user's external ID
+- `{role}`: The user's role
+- `{presenter}`: `true` if the user is a presenter, otherwise `false`
+- `{genericLinkShare_KEY}`: Any additional user metadata field, where `KEY` is the metadata key name (e.g., `{genericLinkShare_info}` will be replaced with the user's *info* if available)
+
+**Note:**  
+To use user metadata as a placeholder, the metadata key must start with the prefix `genericLinkShare_`. For example, if you pass `userdata-genericLinkShare_mykey=12345` when joining, you can use `{genericLinkShare_mykey}` in your shared URL.
+
+
+If additional user metadata is available, you can also use placeholders matching those metadata keys.
+
+
+### Example
+
+If you enter the following link to share:
+
+```
+https://bigbluebutton.org/?name={name}&id={extId}&role={role}&presenter={presenter}&pass={genericLinkShare_mykey}
+```
+
+Each participant will see a personalized link with their own name, role, and the value of `genericLinkShare_mykey` (if set) substituted in the URL.
+
+### Security
+
+Sensitive placeholders are replaced securely to prevent injection or misuse. Only the placeholders listed above and those present in user metadata with the `genericLinkShare_` prefix are supported.
+
 ## Development mode
 
 As for development mode (running this plugin from source), please, refer back to https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk section `Running the Plugin from Source`

--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ When sharing a link, you can use placeholders in the URL that will be dynamicall
 - `{genericLinkShare_KEY}`: Any additional user metadata field, where `KEY` is the metadata key name (e.g., `{genericLinkShare_info}` will be replaced with the user's *info* if available)
 
 **Note:**  
-To use user metadata as a placeholder, the metadata key must start with the prefix `genericLinkShare_`. For example, if you pass `userdata-genericLinkShare_mykey=12345` when joining, you can use `{genericLinkShare_mykey}` in your shared URL.
+To use user metadata as a placeholder, the metadata key must start with the prefix `genericLinkShare_`. 
+For example, if the metadata is `{genericLinkShare_mykey}`, in the join call, it is necessary to send:
+
+```
+  userdata-genericLinkShare_mykey=abc_example
+```
 
 
 If additional user metadata is available, you can also use placeholders matching those metadata keys.

--- a/src/components/generic-link-share/component.tsx
+++ b/src/components/generic-link-share/component.tsx
@@ -22,7 +22,7 @@ import { DataToGenericLink, DecreaseVolumeOnSpeakProps, UserMetadataGraphqlRespo
 import { ModalToShareLink } from '../modal-to-share-link/component';
 import { LinkTag } from '../modal-to-share-link/types';
 import { REGEX } from './constants';
-import { replaceUrlPlaceholders, replaceUrlPlaceholdersSecure } from './utils';
+import { replaceUrlPlaceholdersSecure } from './utils';
 import { USER_METADATA } from './subscription';
 
 function GenericLinkShare(
@@ -259,8 +259,12 @@ function GenericLinkShare(
             root.render(
               <GenericComponentLinkShare
                 link={link && currentUser && data.user_metadata.length !== 0
-                  ? replaceUrlPlaceholdersSecure(link, currentUserPlaceholders, data.user_metadata)
-                  : replaceUrlPlaceholders(link, currentUserPlaceholders)}
+                  ? replaceUrlPlaceholdersSecure(
+                    link,
+                    currentUserPlaceholders,
+                    data.user_metadata,
+                  )
+                  : link}
               />,
             );
             return root;

--- a/src/components/generic-link-share/subscription.ts
+++ b/src/components/generic-link-share/subscription.ts
@@ -9,4 +9,13 @@ subscription MeetingSubscription {
 }
 `;
 
-export default MEETING_SUBSCRIPTION;
+const USER_METADATA = `
+ subscription {
+    user_metadata {
+        parameter
+        value
+    }
+}
+`;
+
+export { MEETING_SUBSCRIPTION, USER_METADATA };

--- a/src/components/generic-link-share/types.ts
+++ b/src/components/generic-link-share/types.ts
@@ -18,6 +18,13 @@ interface DataToGenericLink {
     viewerUrl?: string
 }
 
+export interface CurrentUserData {
+  name: string;
+  extId: string;
+  role: string;
+  presenter: boolean;
+}
+
 export interface UserMetadata {
     parameter: string;
     value: string;

--- a/src/components/generic-link-share/types.ts
+++ b/src/components/generic-link-share/types.ts
@@ -34,4 +34,9 @@ export interface UserMetadataGraphqlResponse {
     user_metadata: UserMetadata[];
 }
 
+export interface PlaceholderEntry {
+  placeholder: string;
+  value: string | boolean;
+}
+
 export { DecreaseVolumeOnSpeakProps, ExternalVideoMeetingSubscription, DataToGenericLink };

--- a/src/components/generic-link-share/types.ts
+++ b/src/components/generic-link-share/types.ts
@@ -18,4 +18,13 @@ interface DataToGenericLink {
     viewerUrl?: string
 }
 
+export interface UserMetadata {
+    parameter: string;
+    value: string;
+}
+
+export interface UserMetadataGraphqlResponse {
+    user_metadata: UserMetadata[];
+}
+
 export { DecreaseVolumeOnSpeakProps, ExternalVideoMeetingSubscription, DataToGenericLink };

--- a/src/components/generic-link-share/utils.ts
+++ b/src/components/generic-link-share/utils.ts
@@ -1,16 +1,11 @@
-import { CurrentUserData, UserMetadata } from './types';
-
-type PlaceholderEntry = {
-  placeholder: string;
-  value: string | boolean;
-}
+import { CurrentUserData, PlaceholderEntry, UserMetadata } from './types';
 
 const DEFAULT_PREFIX = 'genericLinkShare';
 
 export function mergePlaceholdersList(
   currentUserParams?: CurrentUserData,
   userdataParams?: UserMetadata[],
-): PlaceholderEntry[] { // nao esqueça de typar a função
+): PlaceholderEntry[] {
   const placeholdersList: PlaceholderEntry[] = [];
 
   if (currentUserParams) {

--- a/src/components/generic-link-share/utils.ts
+++ b/src/components/generic-link-share/utils.ts
@@ -7,6 +7,8 @@ type PlaceholderValues = {
   presenter: boolean;
 };
 
+const DEFAULT_PREFIX = 'genericLinkShare';
+
 export function replaceUrlPlaceholders(url: string, values: PlaceholderValues): string {
   return url
     .replace(/{name}/g, encodeURIComponent(values.name))
@@ -20,17 +22,13 @@ export function replaceUrlPlaceholdersSecure(
   placeholderValues?: PlaceholderValues,
   userdataParams?: UserMetadata[],
 ): string {
-  // list available userdata parameters
-  const allowedUserdataParams = ['plugin_generic_link_share_mykey'];
-
-  // filter allowed userdata parameters
-  const foundUserdataParams = userdataParams?.filter(
-    (entry) => allowedUserdataParams.includes(entry.parameter),
-  ) || [];
+  const allowedUserdataParams = userdataParams?.filter(
+    (entry) => entry.parameter.startsWith(DEFAULT_PREFIX),
+  );
 
   let result = replaceUrlPlaceholders(url, placeholderValues);
 
-  foundUserdataParams.forEach((userdata) => {
+  allowedUserdataParams.forEach((userdata) => {
     const regexPattern = userdata.parameter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     result = result.replace(
       new RegExp(regexPattern, 'g'),

--- a/src/components/generic-link-share/utils.ts
+++ b/src/components/generic-link-share/utils.ts
@@ -1,3 +1,5 @@
+import { UserMetadata } from './types';
+
 type PlaceholderValues = {
   name: string;
   extId: string;
@@ -11,4 +13,30 @@ export function replaceUrlPlaceholders(url: string, values: PlaceholderValues): 
     .replace(/{extId}/g, encodeURIComponent(values.extId))
     .replace(/{role}/g, encodeURIComponent(values.role))
     .replace(/{presenter}/g, encodeURIComponent(String(values.presenter)));
+}
+
+export function replaceUrlPlaceholdersSecure(
+  url: string,
+  placeholderValues?: PlaceholderValues,
+  userdataParams?: UserMetadata[],
+): string {
+  // list available userdata parameters
+  const allowedUserdataParams = ['plugin_generic_link_share_mykey'];
+
+  // filter allowed userdata parameters
+  const foundUserdataParams = userdataParams?.filter(
+    (entry) => allowedUserdataParams.includes(entry.parameter),
+  ) || [];
+
+  let result = replaceUrlPlaceholders(url, placeholderValues);
+
+  foundUserdataParams.forEach((userdata) => {
+    const regexPattern = userdata.parameter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    result = result.replace(
+      new RegExp(regexPattern, 'g'),
+      encodeURIComponent(userdata.value),
+    );
+  });
+
+  return result;
 }

--- a/src/components/generic-link-share/utils.ts
+++ b/src/components/generic-link-share/utils.ts
@@ -9,32 +9,34 @@ type PlaceholderValues = {
 
 const DEFAULT_PREFIX = 'genericLinkShare';
 
-export function replaceUrlPlaceholders(url: string, values: PlaceholderValues): string {
-  return url
-    .replace(/{name}/g, encodeURIComponent(values.name))
-    .replace(/{extId}/g, encodeURIComponent(values.extId))
-    .replace(/{role}/g, encodeURIComponent(values.role))
-    .replace(/{presenter}/g, encodeURIComponent(String(values.presenter)));
-}
-
 export function replaceUrlPlaceholdersSecure(
   url: string,
   placeholderValues?: PlaceholderValues,
   userdataParams?: UserMetadata[],
 ): string {
-  const allowedUserdataParams = userdataParams?.filter(
-    (entry) => entry.parameter.startsWith(DEFAULT_PREFIX),
-  );
+  let result = url;
 
-  let result = replaceUrlPlaceholders(url, placeholderValues);
+  if (placeholderValues) {
+    result = result
+      .replace(/{name}/g, encodeURIComponent(placeholderValues.name))
+      .replace(/{extId}/g, encodeURIComponent(placeholderValues.extId))
+      .replace(/{role}/g, encodeURIComponent(placeholderValues.role))
+      .replace(/{presenter}/g, encodeURIComponent(String(placeholderValues.presenter)));
+  }
 
-  allowedUserdataParams.forEach((userdata) => {
-    const regexPattern = userdata.parameter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    result = result.replace(
-      new RegExp(regexPattern, 'g'),
-      encodeURIComponent(userdata.value),
+  if (userdataParams) {
+    const allowedUserdataParams = userdataParams?.filter(
+      (entry) => entry.parameter.startsWith(DEFAULT_PREFIX),
     );
-  });
+
+    allowedUserdataParams.forEach((userdata) => {
+      const userdataUrlParameterPattern = `{${userdata.parameter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}}`;
+      const userdataUrlValuePattern = userdata.value.replace(/[.*+?^${}()|[\]\\]/g, '');
+
+      result = result
+        .replace(new RegExp(userdataUrlParameterPattern, 'g'), encodeURIComponent(userdataUrlValuePattern));
+    });
+  }
 
   return result;
 }


### PR DESCRIPTION

### What does this PR do?

This PR improves the Generic Link Share plugin by enhancing the logic to accept userdata params and use the values as placeholders.
Key changes include:
- user metadata subscription and placeholder replacement for secure URL sharing.

### Closes Issue(s)
Closes #27 

### Motivation
These changes aim to make the link sharing experience more robust, ensuring that URLs are handled securely and that the UI responds correctly to data updates.


Please review and let me know if further adjustments are required!
