### PR TITLE
fix: Modal priority set to low

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/react": "^18.2.13",
         "@types/react-dom": "^18.2.7",
         "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "bigbluebutton-html-plugin-sdk": "0.0.84",
+        "bigbluebutton-html-plugin-sdk": "0.0.93",
         "path": "^0.12.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3483,9 +3483,9 @@
       "dev": true
     },
     "node_modules/bigbluebutton-html-plugin-sdk": {
-      "version": "0.0.84",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.84.tgz",
-      "integrity": "sha512-ZaCrwxyYUv2G7HZGfOqPWZzK6QBucb7BEFS/sBuwyJhvlfMKKMdmrYdfDETZ0cGjEV4neFxf1KyCjtpQTm9+iA==",
+      "version": "0.0.93",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.93.tgz",
+      "integrity": "sha512-oA6qdOmNm93tYGo0xedHF+tAeTrq3rgd7es7WP/VBWP/vMfLNOCjhLQ4BM55tckA1xhAGuEnwR0+SXBE7ot9hg==",
       "dependencies": {
         "@apollo/client": "^3.8.7",
         "@browser-bunyan/console-formatted-stream": "^1.8.0",
@@ -12365,9 +12365,9 @@
       "dev": true
     },
     "bigbluebutton-html-plugin-sdk": {
-      "version": "0.0.84",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.84.tgz",
-      "integrity": "sha512-ZaCrwxyYUv2G7HZGfOqPWZzK6QBucb7BEFS/sBuwyJhvlfMKKMdmrYdfDETZ0cGjEV4neFxf1KyCjtpQTm9+iA==",
+      "version": "0.0.93",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.93.tgz",
+      "integrity": "sha512-oA6qdOmNm93tYGo0xedHF+tAeTrq3rgd7es7WP/VBWP/vMfLNOCjhLQ4BM55tckA1xhAGuEnwR0+SXBE7ot9hg==",
       "requires": {
         "@apollo/client": "^3.8.7",
         "@browser-bunyan/console-formatted-stream": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/react": "^18.2.13",
     "@types/react-dom": "^18.2.7",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
-    "bigbluebutton-html-plugin-sdk": "0.0.84",
+    "bigbluebutton-html-plugin-sdk": "0.0.93",
     "path": "^0.12.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/public/index.html
+++ b/public/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Plugin decrease volume on speak"
+      content="Plugin Generic Link Share"
     />
-    <title>Decrease volume on speak</title>
+    <title>Plugin Generic Link Share</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/generic-link-share/component.tsx
+++ b/src/components/generic-link-share/component.tsx
@@ -21,7 +21,7 @@ import GenericComponentLinkShare from '../generic-component/component';
 import {
   CurrentUserData,
   DataToGenericLink,
-  DecreaseVolumeOnSpeakProps,
+  GenericLinkShareProps,
   UserMetadataGraphqlResponse,
 } from './types';
 import { ModalToShareLink } from '../modal-to-share-link/component';
@@ -31,7 +31,7 @@ import { mergePlaceholdersList, replaceUrlPlaceholders } from './utils';
 import { USER_METADATA } from './subscription';
 
 function GenericLinkShare(
-  { pluginUuid: uuid }: DecreaseVolumeOnSpeakProps,
+  { pluginUuid: uuid }: GenericLinkShareProps,
 ): React.ReactElement {
   BbbPluginSdk.initialize(uuid);
   const pluginApi: PluginApi = BbbPluginSdk.getPluginApi(uuid);

--- a/src/components/generic-link-share/types.ts
+++ b/src/components/generic-link-share/types.ts
@@ -1,4 +1,4 @@
-interface DecreaseVolumeOnSpeakProps {
+interface GenericLinkShareProps {
     pluginName: string,
     pluginUuid: string,
 }
@@ -39,4 +39,4 @@ export interface PlaceholderEntry {
   value: string | boolean;
 }
 
-export { DecreaseVolumeOnSpeakProps, ExternalVideoMeetingSubscription, DataToGenericLink };
+export { GenericLinkShareProps, ExternalVideoMeetingSubscription, DataToGenericLink };

--- a/src/components/modal-to-share-link/component.tsx
+++ b/src/components/modal-to-share-link/component.tsx
@@ -39,9 +39,9 @@ export function ModalToShareLink(props: ModalToShareLinkProps) {
     } else setIsViewerUrlAlreadyFormated(false);
   }, [previousModalState]);
 
-  return (
+  return showModal && (
     <Styled.PluginModal
-      className="modal-high"
+      portalClassName="modal-low"
       overlayClassName="modalOverlay"
       ariaHideApp={false}
       isOpen={showModal}

--- a/src/components/modal-to-share-link/component.tsx
+++ b/src/components/modal-to-share-link/component.tsx
@@ -42,6 +42,7 @@ export function ModalToShareLink(props: ModalToShareLinkProps) {
   return showModal && (
     <Styled.PluginModal
       portalClassName="modal-low"
+      parentSelector={() => document.querySelector('#modals-container')}
       overlayClassName="modalOverlay"
       ariaHideApp={false}
       isOpen={showModal}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
         "target": "es5",
         "jsx": "react",
         "allowJs": true,
-	"skipLibCheck": true,
         "moduleResolution": "node",
         "esModuleInterop": true
     },


### PR DESCRIPTION
### What does this PR do?

- changes modal priority to be low (to follow what we currently have with the pick-random-user plugin);
- updated sdk version;
- remove last references to the decrease volume on speak plugin (used as a template to create this plugin);

### Motivation

Pick-random-user plugin had some trouble resolving conflicts between 2 different modals rendering at the same time. Even though that should not happen for this plugin, with this fix, it solves for good, this problem.

### More

Just for reference, the PR from pick-random-user mentioned here is this: [pick-random-user#74](https://github.com/bigbluebutton/plugin-pick-random-user/pull/74)
